### PR TITLE
feat: pdf loader test

### DIFF
--- a/circuits/company-chat/rag.ts
+++ b/circuits/company-chat/rag.ts
@@ -7,6 +7,7 @@ import {
   EaCCompoundDocumentLoaderDetails,
   EaCDenoKVIndexerDetails,
   EaCDenoKVSaverPersistenceDetails,
+  EaCDFSDocumentLoaderDetails,
   EaCGraphCircuitDetails,
   lastAiNotHumanMessages,
 } from '@fathym/synaptic';
@@ -25,6 +26,7 @@ export const Configure: CircuitConfiguration<'Graph'> = (
   ctx: CircuitContext
 ) => {
   const AIHuntersCompanyInfoUrls = loadCompanyInfoUrls();
+  const AIHuntersCompanyInfoPdfs = loadCompanyInfoPdfs();
 
   return {
     AIaC: {
@@ -50,14 +52,25 @@ export const Configure: CircuitConfiguration<'Graph'> = (
 
           return acc;
         }, {} as Record<string, { Details: EaCCheerioWebDocumentLoaderDetails }>),
+
+        ["pdf-loader"]: {
+          Details: {
+            Type: 'DFSDocument',
+            DFSLookup: "local:document-store",
+            Documents: AIHuntersCompanyInfoPdfs,
+          } as EaCDFSDocumentLoaderDetails,
+        },
+
         ['company-chat']: {
           Details: {
             Type: 'CompoundDocument',
-            LoaderLookups: AIHuntersCompanyInfoUrls.map((url) =>
-              ctx.AIaCLookup(url)
-            ),
+            LoaderLookups: [
+              ...AIHuntersCompanyInfoUrls.map((url) => ctx.AIaCLookup(url)),
+              ctx.AIaCLookup("pdf-loader")
+            ]
           } as EaCCompoundDocumentLoaderDetails,
         },
+
       },
       Persistence: {
         'company-chat': {
@@ -193,5 +206,12 @@ function loadCompanyInfoUrls() {
     'https://cognitivemill.com/about/',
     'https://klipmeapp.com/',
     'https://klipmeapp.com/how-it-works',
+  ];
+}
+
+function loadCompanyInfoPdfs() {
+  return [
+    'testmill.pdf',
+    'testclick.pdf',
   ];
 }

--- a/src/plugins/SynapticRuntimePlugin.ts
+++ b/src/plugins/SynapticRuntimePlugin.ts
@@ -108,6 +108,13 @@ export default class SynapticRuntimePlugin implements EaCRuntimePlugin {
           },
         },
         DFSs: {
+          'local:document-store': {
+            Details: {
+              Type: 'Local',
+              FileRoot: './store/',
+              Extensions: [".pdf"],
+            } as EaCLocalDistributedFileSystemDetails,
+          },
           'local:circuits': {
             Details: {
               Type: 'Local',

--- a/store/testclick.pdf
+++ b/store/testclick.pdf
@@ -1,0 +1,71 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 164>>
+stream
+xœUŽ±‚0„wžâFMHm+XÕèàÜÀòªM!m	ñíUƒëÝ}ùNâ–qV*ÌÙIcw’qÝá¢3ÉªBA/Ý^0QCÕ%SŸ¨ÅæhûÉ'
+³u®™¼éÑÀÓŒ1ídRM15ÏÖCrY1èžÖÁ½¹&Q‹4 ŽCH1ßB?¾ø¿ÿ X!ÉØÎšÆ¹yo#[¡7c>^
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20241201224059)
+>>
+endobj
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000321 00000 n 
+0000000504 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000408 00000 n 
+0000000608 00000 n 
+0000000717 00000 n 
+trailer
+<<
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+>>
+startxref
+820
+%%EOF

--- a/store/testmill.pdf
+++ b/store/testmill.pdf
@@ -1,0 +1,71 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 166>>
+stream
+xœU±‚0Ew¾âšÚR±2j¢ƒs ”g¨ÖBh	ñïEƒÛMNNÎ-pË8+¦ì¬±»
+ˆ‚q}ÇEg’É£€^˜LTPUÉ”‚n°9¹v‰†ˆÉyoÆ`[šĞ]3Ú”CSL¯çp—œA·´òŸYò&QƒÔ!öİb¾…~|/ğÿüA±}±äcOÖİ5Ş¿Q›ø¤TÏ›­âÊò?
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+6 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20241201223000)
+>>
+endobj
+7 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 8
+0000000000 65535 f 
+0000000323 00000 n 
+0000000506 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000410 00000 n 
+0000000610 00000 n 
+0000000719 00000 n 
+trailer
+<<
+/Size 8
+/Root 7 0 R
+/Info 6 0 R
+>>
+startxref
+822
+%%EOF


### PR DESCRIPTION
## Summary

This PR implements the following task:
**Task**: Modify the current Fathym RAG solution to ingest parseable PDFs and perform RAG search over PDF contents.

## Background

The basis for this solution was derived from the discussion in [Issue #1](https://github.com/fathym-deno/synaptic/issues/1)

## Screenshots

Below is a screenshot demonstrating the successful indexing and RAG search over the PDF contents:

<img width="298" alt="Screenshot 2024-12-02 at 00 58 05" src="https://github.com/user-attachments/assets/711d30b2-c8f0-4535-8fbd-5c54e5b3cf91">

